### PR TITLE
[Test and Build] Reduce Indentation level, use escapeshellarg for recipe filename, added basic comments and `PHP_EOL` instead of \n for output strings

### DIFF
--- a/scripts/testAndBuild.php
+++ b/scripts/testAndBuild.php
@@ -11,7 +11,7 @@ if (count($argv) > 1) {
     $oicdbVersion = $argv[1];
 }
 
-$recipeDirectoryPath = PATH . '/recipes1/';
+$recipeDirectoryPath = PATH . '/recipes/';
 $handle = opendir($recipeDirectoryPath);
 if (!$handle) {
     throw new \RuntimeException(sprintf('Directory %s could not be opened', $recipeDirectoryPath));

--- a/scripts/testAndBuild.php
+++ b/scripts/testAndBuild.php
@@ -25,10 +25,11 @@ while (false !== ($filename = readdir($handle))) {
         continue;
     }
 
+    $recipeFilePath = PATH . '/recipes/' . $filename;
     $output .= "Validating: $filename";
-    $recipe = file_get_contents(PATH .'/recipes/' . $filename);
+    $recipe = file_get_contents($recipeFilePath);
     $lastGitChangeTimestamp = '';
-    exec('git log -1 --pretty="format:%at" -- ' . PATH . '/recipes/' . $filename, $lastGitChangeTimestamp);
+    exec('git log -1 --pretty="format:%at" -- ' . escapeshellarg($recipeFilePath), $lastGitChangeTimestamp);
     $version = $lastGitChangeTimestamp[0] . '-' . sha1($recipe);
     $recipe = str_replace('"type":', '"version": "' . $version . '",' . "\n" . '  "type":', $recipe);
     $content = str_replace('"recipes": []', '"recipes": [' . $recipe . ']', $repositoryTemplate);

--- a/scripts/testAndBuild.php
+++ b/scripts/testAndBuild.php
@@ -67,7 +67,7 @@ echo "Build finished succesfully" . PHP_EOL;
 echo $output;
 $hash = sha1($contentRecipes);
 
-//Create build directory
+// Create build directory
 $dir = PATH . '/build';
 if (!is_dir($dir)) {
     if (!mkdir($dir) && !is_dir($dir)) {
@@ -75,14 +75,15 @@ if (!is_dir($dir)) {
     }
 }
 
-//Normal build
+// Normal build
 if (strlen($oicdbVersion) <= 0) {
     $oicdbVersion = date('YmdHis') . '-' . $hash;
     $content = str_replace('###VERSION###', $oicdbVersion, $repositoryTemplate);
     $content = str_replace('"recipes": []', '"recipes": [' . "\n" . $contentRecipes . "\n" . '  ]', $content);
     file_put_contents(PATH . '/build/oicdb-dev.json', $content);
+
 } else {
-    //Release version
+    // Release version
     $content = str_replace('###VERSION###', $oicdbVersion, $repositoryTemplate);
     $content = str_replace('"recipes": []', '"recipes": [' . "\n" . $contentRecipes . "\n" . '  ]', $content);
     file_put_contents(PATH . '/build/oicdb-' . $oicdbVersion. '.json', $content);

--- a/scripts/testAndBuild.php
+++ b/scripts/testAndBuild.php
@@ -25,6 +25,8 @@ while (false !== ($filename = readdir($handle))) {
         continue;
     }
 
+    // Reading recipe and determining the current version
+    // The last git change timestamp is used as a version string
     $recipeFilePath = PATH . '/recipes/' . $filename;
     $output .= "Validating: $filename";
     $recipe = file_get_contents($recipeFilePath);
@@ -37,15 +39,17 @@ while (false !== ($filename = readdir($handle))) {
         $contentRecipes .= ",\n";
     }
     $contentRecipes .= '    ' . $recipe;
+
+    // JSON Schema validation for a single recipe
     $data = json_decode($content, false);
-    $validator = new JsonSchema\Validator;
+    $validator = new JsonSchema\Validator();
     $validator->validate($data, (object)['$ref' => 'file://' . PATH . '/schema/oicdb.schema.json']);
     if ($validator->isValid()) {
-        $output .= " - OK\n";
+        $output .= " - OK" . PHP_EOL;
     } else {
-        $output .= " - ERROR\n";
+        $output .= " - ERROR" . PHP_EOL;
         foreach ($validator->getErrors() as $error) {
-            $output = sprintf("[%s] %s\n", $error['property'], $error['message']);
+            $output = sprintf("[%s] %s" . PHP_EOL, $error['property'], $error['message']);
             ++$numErrors;
         }
     }
@@ -54,12 +58,12 @@ while (false !== ($filename = readdir($handle))) {
 
 closedir($handle);
 if ($numErrors > 0) {
-    echo "Found $numErrors errors\n";
+    echo "Found $numErrors errors" . PHP_EOL;
     echo $output;
     throw new \RuntimeException(sprintf('Found %s errors', $numErrors));
 }
 
-echo "Build finished succesfully\n";
+echo "Build finished succesfully" . PHP_EOL;
 echo $output;
 $hash = sha1($contentRecipes);
 

--- a/scripts/testAndBuild.php
+++ b/scripts/testAndBuild.php
@@ -1,75 +1,83 @@
 #!/usr/bin/env php
 <?php
 include_once 'vendor/autoload.php';
+
 define('PATH', realpath('..'));
-$repositoryTemplate = file_get_contents( 'templates/repository.json');
+
+$repositoryTemplate = file_get_contents('templates/repository.json');
 $contentRecipes = '';
 $oicdbVersion = '';
 if (count($argv) > 1) {
     $oicdbVersion = $argv[1];
 }
-if ($handle = opendir(PATH . '/recipes/')) {
-    $output = '';
-    $numErrors = 0;
-    $numRecipes = 0;
-    while (false !== ($filename = readdir($handle))) {
-        if ($filename !== "." && $filename !== "..") {
-            $output .= "Validating: $filename";
-            $recipe = file_get_contents(PATH .'/recipes/' . $filename);
-            $lastGitChangeTimestamp = '';
-            exec('git log -1 --pretty="format:%at" -- ' . PATH . '/recipes/' . $filename, $lastGitChangeTimestamp);
-            $version = $lastGitChangeTimestamp[0] . '-' . sha1($recipe);
-            $recipe = str_replace('"type":', '"version": "' . $version . '",' . "\n" . '  "type":', $recipe);
-            $content = str_replace('"recipes": []', '"recipes": [' . $recipe . ']', $repositoryTemplate);
-            if ($numRecipes > 0) {
-                $contentRecipes .= ",\n";
-            }
-            $contentRecipes .= '    ' . $recipe;
-            $data = json_decode($content, false);
-            $validator = new JsonSchema\Validator;
-            $validator->validate($data, (object)['$ref' => 'file://' . PATH . '/schema/oicdb.schema.json']);
-            if ($validator->isValid()) {
-                $output .= " - OK\n";
-            } else {
-                $output .= " - ERROR\n";
-                foreach ($validator->getErrors() as $error) {
-                    $output = sprintf("[%s] %s\n", $error['property'], $error['message']);
-                    ++$numErrors;
-                }
-            }
-            ++$numRecipes;
-        }
-    }
-    closedir($handle);
-    if ($numErrors > 0) {
-        echo "Found $numErrors errors\n";
-        echo $output;
-        throw new \RuntimeException(sprintf('Found %s errors', $numErrors));
-    }
 
-    echo "Build finished succesfully\n";
+$recipeDirectoryPath = PATH . '/recipes1/';
+$handle = opendir($recipeDirectoryPath);
+if (!$handle) {
+    throw new \RuntimeException(sprintf('Directory %s could not be opened', $recipeDirectoryPath));
+}
+
+$output = '';
+$numErrors = 0;
+$numRecipes = 0;
+while (false !== ($filename = readdir($handle))) {
+    if ($filename !== "." && $filename !== "..") {
+        $output .= "Validating: $filename";
+        $recipe = file_get_contents(PATH .'/recipes/' . $filename);
+        $lastGitChangeTimestamp = '';
+        exec('git log -1 --pretty="format:%at" -- ' . PATH . '/recipes/' . $filename, $lastGitChangeTimestamp);
+        $version = $lastGitChangeTimestamp[0] . '-' . sha1($recipe);
+        $recipe = str_replace('"type":', '"version": "' . $version . '",' . "\n" . '  "type":', $recipe);
+        $content = str_replace('"recipes": []', '"recipes": [' . $recipe . ']', $repositoryTemplate);
+        if ($numRecipes > 0) {
+            $contentRecipes .= ",\n";
+        }
+        $contentRecipes .= '    ' . $recipe;
+        $data = json_decode($content, false);
+        $validator = new JsonSchema\Validator;
+        $validator->validate($data, (object)['$ref' => 'file://' . PATH . '/schema/oicdb.schema.json']);
+        if ($validator->isValid()) {
+            $output .= " - OK\n";
+        } else {
+            $output .= " - ERROR\n";
+            foreach ($validator->getErrors() as $error) {
+                $output = sprintf("[%s] %s\n", $error['property'], $error['message']);
+                ++$numErrors;
+            }
+        }
+        ++$numRecipes;
+    }
+}
+
+closedir($handle);
+if ($numErrors > 0) {
+    echo "Found $numErrors errors\n";
     echo $output;
-    $hash = sha1($contentRecipes);
+    throw new \RuntimeException(sprintf('Found %s errors', $numErrors));
+}
 
-    //Create build directory
-    $dir = PATH . '/build';
-    if (!is_dir($dir)) {
-        if (!mkdir($dir) && !is_dir($dir)) {
-            throw new \RuntimeException(sprintf('Directory "%s" was not created', $dir));
-        }
-    }
+echo "Build finished succesfully\n";
+echo $output;
+$hash = sha1($contentRecipes);
 
-    //Normal build
-    if (strlen($oicdbVersion) <= 0) {
-        $oicdbVersion = date('YmdHis') . '-' . $hash;
-        $content = str_replace('###VERSION###', $oicdbVersion, $repositoryTemplate);
-        $content = str_replace('"recipes": []', '"recipes": [' . "\n" . $contentRecipes . "\n" . '  ]', $content);
-        file_put_contents(PATH . '/build/oicdb-dev.json', $content);
-    } else {
-        //Release version
-        $content = str_replace('###VERSION###', $oicdbVersion, $repositoryTemplate);
-        $content = str_replace('"recipes": []', '"recipes": [' . "\n" . $contentRecipes . "\n" . '  ]', $content);
-        file_put_contents(PATH . '/build/oicdb-' . $oicdbVersion. '.json', $content);
-        copy(PATH . '/build/oicdb-' . $oicdbVersion. '.json', PATH . '/build/oicdb-latest.json');
+//Create build directory
+$dir = PATH . '/build';
+if (!is_dir($dir)) {
+    if (!mkdir($dir) && !is_dir($dir)) {
+        throw new \RuntimeException(sprintf('Directory "%s" was not created', $dir));
     }
+}
+
+//Normal build
+if (strlen($oicdbVersion) <= 0) {
+    $oicdbVersion = date('YmdHis') . '-' . $hash;
+    $content = str_replace('###VERSION###', $oicdbVersion, $repositoryTemplate);
+    $content = str_replace('"recipes": []', '"recipes": [' . "\n" . $contentRecipes . "\n" . '  ]', $content);
+    file_put_contents(PATH . '/build/oicdb-dev.json', $content);
+} else {
+    //Release version
+    $content = str_replace('###VERSION###', $oicdbVersion, $repositoryTemplate);
+    $content = str_replace('"recipes": []', '"recipes": [' . "\n" . $contentRecipes . "\n" . '  ]', $content);
+    file_put_contents(PATH . '/build/oicdb-' . $oicdbVersion. '.json', $content);
+    copy(PATH . '/build/oicdb-' . $oicdbVersion. '.json', PATH . '/build/oicdb-latest.json');
 }


### PR DESCRIPTION
This Pull Request **is not changing the behaviour ** of the `testAndBuild.php` script.
It provides a few changes with the goal of

* early failure
* readability
* minimal security
* and platform (OS) independence

The change seems big, but it is only due to reducing the indention level. If the change is compared without whitespace changes, it becomes clearer.
I suggest to review commit by commit:

* 1a7d1f4 - (HEAD -> improve-test-and-build-script, fork/improve-test-and-build-script) [Test and Build] Add whitespace to comments for readability
* 368b131 - [Test and Build] Use `PHP_EOL` instead of `\n` for output strings to be platform independent
* 4dcf1e9 - [Test and Build] Escaped recipe name via `escapeshellarg` to avoid security issues by arbitrary filename
* 546960a - [Test and Build] Fix path to recipes (changed for failure testing)
* 88257db - [Test and Build] Reduce Indentation level by one in while loop via negating check for `.` and `..`
* ffeaeb0 - [Test and Build] Reduce Indentation level by one via checking on a `opendir` failure first