### PR TITLE
BUGFIX: Add btn-download class to hetzner invoice selector

### DIFF
--- a/recipes/hetzner.json
+++ b/recipes/hetzner.json
@@ -78,7 +78,7 @@
     },
     {
       "action": "downloadAll",
-      "selector": "ul.invoice-list > li > div > div > div > div > a",
+      "selector": "ul.invoice-list > li > div > div > div > div > a.btn-download",
       "description": "Click all PDF links and download invoices."
     },
     {


### PR DESCRIPTION
There's a new link in the invoice list, that caused the old recipe to fail downloading only the pdf invoices.